### PR TITLE
Two Changes

### DIFF
--- a/app/controllers/gigs_controller.rb
+++ b/app/controllers/gigs_controller.rb
@@ -93,7 +93,11 @@ class GigsController < ApplicationController
     @gig = Gig.new(params)
 
     if @gig.save
-      @gig.gigsets.create(setlist_songs)
+
+      if setlist_songs.present?
+        @gig.gigsets.create(setlist_songs)
+      end
+      
       return_to_previous_page(@gig)
     else
       # This line overrides the default rendering behavior, which

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>RobynBase</title>
+  <title>The Asking Tree</title>
 
   <%= favicon_link_tag 'images/favicon.ico' %>
   
@@ -12,6 +12,8 @@
   <%= csrf_meta_tags %>
 
   <meta charset="utf-8" name="viewport" content="width=device-width, scale=1.0">
+
+  <meta name="description" content="Comprehensive fan-made database covering the songs, concerts and releases of English singer-songwriter Robyn Hitchcock.">
 
 </head>
 <body>


### PR DESCRIPTION
1. Bug: When saving a gig with no setlist, the app would automatically create a setlist with a single, empty song.
2. Improve the description of the site that appears on search engines.