### PR TITLE
Fix Archive.org Playlist Height

### DIFF
--- a/app/helpers/gig_helper.rb
+++ b/app/helpers/gig_helper.rb
@@ -35,7 +35,7 @@ module GigHelper
     case gig_medium.mediatype
       
       when Gigmedium::MEDIA_TYPE["ArchiveOrgPlaylist"]
-        210
+        230
         
       when Gigmedium::MEDIA_TYPE["ArchiveOrg"]
         480


### PR DESCRIPTION
Fix height of Archive.org playlists, so that we don't cut off the final song.