### PR TITLE
Fixes for production implementation of image uploads

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,7 @@ gem 'bootsnap'
 gem 'sass-rails'
 gem 'coffee-rails'
 
-# supports active storage image manipulation
-gem 'image_processing', '>= 1.2'
+# supports active storage image variants
 gem 'mini_magick'
 
 # Gems used only for assets and not required

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,9 +77,6 @@ GEM
       activesupport (>= 5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
-    image_processing (1.12.2)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -139,8 +136,6 @@ GEM
     rb-fsevent (0.11.1)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    ruby-vips (2.1.4)
-      ffi (~> 1.12)
     rvm1-capistrano3 (1.4.0)
       capistrano (~> 3.0)
       sshkit (>= 1.2)
@@ -191,7 +186,6 @@ DEPENDENCIES
   capistrano (= 3.3.5)
   capistrano-rails (= 1.1.3)
   coffee-rails
-  image_processing (>= 1.2)
   jquery-rails
   listen
   mini_magick

--- a/app/controllers/gigs_controller.rb
+++ b/app/controllers/gigs_controller.rb
@@ -1,6 +1,4 @@
 class GigsController < ApplicationController
-
-  require 'image_processing/mini_magick'
   
   authorize_resource :only => [:new, :edit, :update, :create, :destroy]
 

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -8,7 +8,7 @@ local:
   
 robyn:
   service: Disk
-  root: <%= ENV["ROBYNBASE_ACTIVESTORAGE_DIR"] %>
+  root: <%= Rails.root.join("../storage") %>
 
 # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
 # amazon:


### PR DESCRIPTION
Use directory relative to current rails install for image storage. Remove dependency on image_processing — use mini_magick alone should be sufficient.