### PR TITLE
Image Gallery Fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
     nio4r (2.5.8)
-    nokogiri (1.13.3)
+    nokogiri (1.13.4)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     racc (1.6.0)

--- a/app/assets/javascripts/gig.js.coffee
+++ b/app/assets/javascripts/gig.js.coffee
@@ -3,7 +3,7 @@
 # You can use CoffeeScript in this file: http://jashkenas.github.com/coffee-script/
 
 
-$(window).on("load", (e) ->
+$(window).on("DOMContentLoaded", (e) ->
 
   # hide show advanced options in list page
   $(".gig-list .advanced-options-header").on("click", (e) ->


### PR DESCRIPTION
1. Set up gig image gallery on 'DOMContentLoaded', instead of 'loaded' (so we're not waiting for media on the page to finish). 
2. Bump the version of nokogiri (to fix a security issue).