### PR TITLE
Improve lat/long precision

### DIFF
--- a/app/javascript/gig.js
+++ b/app/javascript/gig.js
@@ -149,8 +149,8 @@ window.$(window).on("DOMContentLoaded", function(e) {
                 name="gig[gigmedia_attributes][${mediaIndex}][mediatype]">              
             <option value="1">YouTube</option>
             <option value="2">Archive.org Video</option>
-            <option selected="selected" value="4">Archive.org Audio</option>
-            <option value="3">Archive.org Playlist</option>
+            <option value="4">Archive.org Audio</option>
+            <option selected="selected" value="3">Archive.org Playlist</option>
             <option value="5">Vimeo</option>
             <option value="6">Soundcloud</option>
         </select>

--- a/app/javascript/gig.js
+++ b/app/javascript/gig.js
@@ -149,7 +149,7 @@ window.$(window).on("DOMContentLoaded", function(e) {
                 name="gig[gigmedia_attributes][${mediaIndex}][mediatype]">              
             <option value="1">YouTube</option>
             <option value="2">Archive.org Video</option>
-            <option value="4">Archive.org Audio</option>
+            <option selected="selected" value="4">Archive.org Audio</option>
             <option value="3">Archive.org Playlist</option>
             <option value="5">Vimeo</option>
             <option value="6">Soundcloud</option>

--- a/db/migrate/20231001125824_change_latitude_longitude_to_be_decimal_in_venue.rb
+++ b/db/migrate/20231001125824_change_latitude_longitude_to_be_decimal_in_venue.rb
@@ -1,0 +1,11 @@
+class ChangeLatitudeLongitudeToBeDecimalInVenue < ActiveRecord::Migration[7.0]
+  def up
+    change_column :VENUE, :latitude, :decimal, :precision => 13, :scale => 9
+    change_column :VENUE, :longitude, :decimal, :precision => 13, :scale => 9
+  end
+
+  def down
+    change_column :VENUE, :latitude, :float
+    change_column :VENUE, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_16_232139) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_01_125824) do
   create_table "COMP", primary_key: "COMPID", id: :integer, charset: "utf8", options: "ENGINE=MyISAM", force: :cascade do |t|
     t.string "Artist", limit: 64
     t.string "Title", limit: 64
@@ -203,8 +203,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_16_232139) do
     t.string "NameSearch", limit: 48
     t.string "SubCity"
     t.text "Notes"
-    t.float "latitude"
-    t.float "longitude"
+    t.decimal "latitude", precision: 13, scale: 9
+    t.decimal "longitude", precision: 13, scale: 9
     t.string "street_address1"
     t.string "street_address2"
     t.index ["Name"], name: "Name"


### PR DESCRIPTION
Switch lat/long columns to decimals (from floats), for better precison. Make Archive.org audio the default media type.