### PR TITLE
Pin stringio to v 0.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,11 @@ gem 'rails', '~> 7.1.0'
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 
+# pin stringio to v 0.1.0 — this gets us around an issue where two stringio instances
+# exist at the same time ("Error: The application encountered the following error: You have
+# already activated stringio 0.1.0, but your Gemfile requires stringio 3.1.7.")
+gem "stringio", "0.1.0"
+
 # gem 'sqlite3'
 gem 'mysql2', '0.5.6'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,7 +255,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
-    stringio (3.1.7)
+    stringio (0.1.0)
     thor (1.3.2)
     tilt (2.6.0)
     timeout (0.4.3)
@@ -296,6 +296,7 @@ DEPENDENCIES
   rvm1-capistrano3
   sass-rails
   sprockets-rails
+  stringio (= 0.1.0)
   uglifier (>= 1.3.0)
   web-console
 


### PR DESCRIPTION
This gets us around an issue where two stringio instances exist at the same time, which was causing startup to fail in production.

("Error: The application encountered the following error: You have already activated stringio 0.1.0, but your Gemfile requires stringio 3.1.7.")