### PR TITLE
Upgrade to Ruby 3.4.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,11 +5,6 @@ gem 'rails', '~> 7.1.0'
 # Bundle edge Rails instead:
 # gem 'rails', :git => 'git://github.com/rails/rails.git'
 
-# pin stringio to v 0.1.0 — this gets us around an issue where two stringio instances
-# exist at the same time ("Error: The application encountered the following error: You have
-# already activated stringio 0.1.0, but your Gemfile requires stringio 3.1.7.")
-gem "stringio", "0.1.0"
-
 # gem 'sqlite3'
 gem 'mysql2', '0.5.6'
 
@@ -67,6 +62,7 @@ gem "cssbundling-rails", "~> 1.1"
 
 group :development do
   gem 'capistrano', '3.3.5'
+  gem "puma"
   gem 'capistrano-rails', '1.1.3'
   gem 'rvm1-capistrano3', require: false
   gem 'web-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     bootsnap (1.18.6)
       msgpack (~> 1.2)
     builder (3.3.0)
-    byebug (11.1.3)
+    byebug (12.0.0)
     cancancan (3.5.0)
     capistrano (3.3.5)
       capistrano-stats (~> 1.1.0)
@@ -108,10 +108,11 @@ GEM
       activerecord (>= 6.1)
       railties (>= 6.1)
     date (3.4.1)
-    drb (2.2.1)
+    drb (2.2.3)
+    erb (5.0.1)
     erubi (1.13.1)
     execjs (2.10.0)
-    ffi (1.17.2)
+    ffi (1.17.2-arm64-darwin)
     globalid (1.2.1)
       activesupport (>= 6.1)
     i18n (1.14.7)
@@ -147,12 +148,11 @@ GEM
       benchmark
       logger
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.25.5)
     msgpack (1.8.0)
     mutex_m (0.3.0)
     mysql2 (0.5.6)
-    net-imap (0.4.22)
+    net-imap (0.5.8)
       date
       net-protocol
     net-pop (0.1.2)
@@ -167,8 +167,7 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
-    nokogiri (1.15.7)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.18.8-arm64-darwin)
       racc (~> 1.4)
     ostruct (0.6.1)
     pp (0.6.2)
@@ -177,6 +176,8 @@ GEM
     psych (5.2.6)
       date
       stringio
+    puma (6.6.0)
+      nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.1.15)
     rack-session (2.1.1)
@@ -200,7 +201,7 @@ GEM
       activesupport (= 7.1.5.1)
       bundler (>= 1.15.0)
       railties (= 7.1.5.1)
-    rails-dom-testing (2.2.0)
+    rails-dom-testing (2.3.0)
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
@@ -219,7 +220,8 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rdoc (6.13.1)
+    rdoc (6.14.0)
+      erb
       psych (>= 4.0.0)
     reline (0.6.1)
       io-console (~> 0.5)
@@ -239,7 +241,7 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    securerandom (0.3.2)
+    securerandom (0.4.1)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -255,7 +257,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
-    stringio (0.1.0)
+    stringio (3.1.7)
     thor (1.3.2)
     tilt (2.6.0)
     timeout (0.4.3)
@@ -272,10 +274,11 @@ GEM
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    zeitwerk (2.6.18)
+    zeitwerk (2.7.3)
 
 PLATFORMS
-  ruby
+  arm64-darwin-23
+  arm64-darwin-24
 
 DEPENDENCIES
   bcrypt (~> 3.1.7)
@@ -292,13 +295,13 @@ DEPENDENCIES
   listen
   mini_magick
   mysql2 (= 0.5.6)
+  puma
   rails (~> 7.1.0)
   rvm1-capistrano3
   sass-rails
   sprockets-rails
-  stringio (= 0.1.0)
   uglifier (>= 1.3.0)
   web-console
 
 BUNDLED WITH
-   2.4.22
+   2.6.9

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -40,7 +40,7 @@ set :pty, true
 
 # had to do this because i don't have any indication in the home directory
 # of which version of ruby rvm is on
-set :rvm1_ruby_version, 'ruby-2.7.8'
+set :rvm1_ruby_version, 'ruby-3.4.4'
 
 # this is used by the built-in 'deploy:symlink:linked_files'. links up the
 # shared database.yml file to the latest release


### PR DESCRIPTION
1. Update to latest versions of several gems
2. Use bundler 2.6.9
3. Update Capistrano deployment to use v 3.4.4 of Ruby