### PR TITLE
Fix Gig Create/Update Error

### DIFF
--- a/app/controllers/gigs_controller.rb
+++ b/app/controllers/gigs_controller.rb
@@ -303,7 +303,7 @@ class GigsController < ApplicationController
     new_params["Venue"] = Venue.find(new_params["VENUEID"].to_i).Name if new_params["Venue"].strip.empty?
 
     # extract the year from the date
-    new_params["GigYear"] = Time.new(params["gig"]["GigDate"]).year
+    new_params["GigYear"] = Date.strptime(params["gig"]["GigDate"], '%Y-%m-%d').year
 
     # if requested, extract images into a separate variable
     if extract_images then

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -30,7 +30,7 @@ set :deploy_via, :copy
 set :ssh_options, { :forward_agent => true }
 
 # keep some releases around on the server
-set :keep_releases, 5
+set :keep_releases, 10
 
 # make sure password prompts and such show up in the terminal
 set :pty, true
@@ -75,7 +75,7 @@ namespace :deploy do
     end
   end
 
-  after :deploy, 'deploy:restart_passenger'
+  after 'deploy:finished', 'deploy:restart_passenger'
 
   after :restart, :clear_cache do
     on roles(:web), in: :groups, limit: 3, wait: 10 do

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,6 +30,10 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
+  # Ensure Rails uses fingerprinted asset names, matching what assets:precompile
+  # generates.
+  config.assets.digest = true
+
   # prevents sprockets from using sass mode and SassC gem (which is based on deprecated LibSass library)
   # in assets:precompile step
   config.assets.css_compressor = nil


### PR DESCRIPTION
The Time.new constructor is more rigid about what date strings it accepts (since Ruby 3.3). Use a different method to extract year from the Gig date.

This also fixes an issue in the production config: the server wasn't looking for fingerprinted asset names, so all its asset fetches were failing.